### PR TITLE
Updated dependency for aws-cloudformation-rpdk-java-plugin

### DIFF
--- a/NrqlAlertCondition/newrelic-alerts-nrqlalert.json
+++ b/NrqlAlertCondition/newrelic-alerts-nrqlalert.json
@@ -55,15 +55,12 @@
           "type": "boolean"
         },
         "ExpectedGroups": {
-          "description": "TODO",
           "type": "integer"
         },
         "IgnoreOverlap": {
-          "description": "TODO",
           "type": "boolean"
         },
         "ValueFunction": {
-          "description": "TODO",
           "type": "string"
         },
         "Terms": {

--- a/NrqlAlertCondition/pom.xml
+++ b/NrqlAlertCondition/pom.xml
@@ -22,10 +22,11 @@
     </repositories>
 
     <dependencies>
-        <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
-            <groupId>com.amazonaws.cloudformation</groupId>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
+            <version>1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/CreateHandler.java
+++ b/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/CreateHandler.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrqlCondition;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.impl.client.HttpClients;

--- a/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/DeleteHandler.java
+++ b/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/DeleteHandler.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.impl.client.HttpClients;
 

--- a/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/ReadHandler.java
+++ b/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/ReadHandler.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrqlCondition;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.impl.client.HttpClients;

--- a/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/UpdateHandler.java
+++ b/NrqlAlertCondition/src/main/java/com/newrelic/alerts/nrqlalert/UpdateHandler.java
@@ -1,10 +1,10 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
-import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
-import com.amazonaws.cloudformation.proxy.OperationStatus;
-import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;

--- a/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/CreateHandlerTest.java
+++ b/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/CreateHandlerTest.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrqlCondition;
 import org.json.JSONArray;

--- a/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/DeleteHandlerTest.java
+++ b/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/DeleteHandlerTest.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;

--- a/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/ReadHandlerTest.java
+++ b/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/ReadHandlerTest.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrql;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrqlCondition;
 import com.newrelic.alerts.nrqlalert.model.NewRelicTerm;

--- a/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/UpdateHandlerTest.java
+++ b/NrqlAlertCondition/src/test/java/com/newrelic/alerts/nrqlalert/UpdateHandlerTest.java
@@ -1,6 +1,6 @@
 package com.newrelic.alerts.nrqlalert;
 
-import com.amazonaws.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.alerts.nrqlalert.model.NewRelicNrqlCondition;
 import org.json.JSONArray;

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
+            <!-- https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/ -->
             <dependency>
-                <groupId>com.amazonaws.cloudformation</groupId>
+                <groupId>software.amazon.cloudformation</groupId>
                 <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
                 <version>1.0</version>
             </dependency>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* In order to publish to Maven we need to update our namespace to AWS' newer Sontatype groupId. This PR fixes this dependency across the repo. 

I also removed some `TODO` statements in the schema, but feel free to replace those with actual documentation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
